### PR TITLE
[5-6-1] keys

### DIFF
--- a/ios/Runner.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/ios/Runner.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "group:Runner.xcodeproj">
+      location = "self:">
    </FileRef>
 </Workspace>

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -63,11 +63,11 @@ class _AppState extends State<_App> {
     return MaterialApp(
       title: 'App title',
       theme: ThemeSettings().currentTheme,
-      // home: VisitingScreen(),
+      home: VisitingScreen(),
       // home: SightDetails(
       //   sight: mocks.first,
       // ),
-      home: SightListScreen(),
+      // home: SightListScreen(),
       // home: FiltersScreen(),
       // home: SettingsScreen(),
       // home: AddSightScreen(),

--- a/lib/ui/screen/sight_card.dart
+++ b/lib/ui/screen/sight_card.dart
@@ -59,9 +59,7 @@ class _BaseCard extends StatelessWidget {
           Material(
             type: MaterialType.transparency,
             child: InkWell(
-              onTap: () {
-
-              },
+              onTap: () {},
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 children: [
@@ -77,8 +75,12 @@ class _BaseCard extends StatelessWidget {
                           Expanded(
                             child: Text(
                               sight!.type.label.toLowerCase(),
-                              style: Theme.of(context).textTheme.subtitle1!.copyWith(
-                                    color: Theme.of(context).colorScheme.onPrimary,
+                              style: Theme.of(context)
+                                  .textTheme
+                                  .subtitle1!
+                                  .copyWith(
+                                    color:
+                                        Theme.of(context).colorScheme.onPrimary,
                                   ),
                             ),
                           ),
@@ -172,8 +174,13 @@ class SightCard extends StatelessWidget {
 
 class FavoriteSightCard extends StatelessWidget {
   final Sight? sight;
+  final void Function() onRemove;
 
-  const FavoriteSightCard({Key? key, this.sight}) : super(key: key);
+  const FavoriteSightCard({
+    Key? key,
+    this.sight,
+    required this.onRemove,
+  }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -201,9 +208,7 @@ class FavoriteSightCard extends StatelessWidget {
           height: 24,
           width: 24,
           child: TextButton(
-            onPressed: () {
-              print('tap close');
-            },
+            onPressed: onRemove,
             style: ButtonStyle(
               shape: MaterialStateProperty.all(CircleBorder()),
               padding: MaterialStateProperty.all(const EdgeInsets.all(0)),

--- a/lib/ui/screen/visiting_screen.dart
+++ b/lib/ui/screen/visiting_screen.dart
@@ -8,7 +8,12 @@ import 'package:places/res/text_constants.dart';
 import 'package:places/ui/screen/sight_card.dart';
 import 'package:places/ui/screen/sight_list_screen.dart';
 
-class VisitingScreen extends StatelessWidget {
+class VisitingScreen extends StatefulWidget {
+  @override
+  _VisitingScreenState createState() => _VisitingScreenState();
+}
+
+class _VisitingScreenState extends State<VisitingScreen> {
   @override
   Widget build(BuildContext context) {
     return DefaultTabController(
@@ -45,6 +50,11 @@ class VisitingScreen extends StatelessWidget {
               cardBuilder: (sight) {
                 return FavoriteSightCard(
                   sight: sight,
+                  onRemove: () {
+                    setState(() {
+                      mocks.remove(sight);
+                    });
+                  },
                 );
               },
             ),


### PR DESCRIPTION
https://user-images.githubusercontent.com/14288495/110622410-38ff7580-81bd-11eb-9545-7924c90b531b.mov

Ответы на вопросы:
1) Какой механизм вам для этого понадобился?
Никакой :D. В данном случай в дереве виджетов присутствуют только stateless виджеты, поэтому они и так перерисуются корректно.
2) Как именно он отработал?
 Вся магия в этом методе https://api.flutter.dev/flutter/widgets/Element/updateChild.html

В нем вызывается `Widget.canUpdate` ,  который проверяет тип виджета и его ключ. Если они не совпадают, старый элемент удаляется и создается новый. Если одинаковые то  у элемента вызывается метод `update`, которы вызовет rebuild виджета. Если виджет stateless  то rebuild произойдет на основании его параметров и удаление отработает корректно. Если виджет statefull то при ребилде буду т использоваться данные из него и дерево обновится некорректно.

Соответственно если бы карточки были statefull нужно было бы использовать ключи что бы пересоздался(либо получился по глобальному ключу) StatefulElement.